### PR TITLE
Upgrade to Netty 3.4.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <version.junit>4.7</version.junit>
     <version.log4j>1.2.16</version.log4j>
     <version.mockito>1.8.4</version.mockito>
-    <version.netty>3.2.1.Final</version.netty>
+    <version.netty>3.4.5.Final</version.netty>
     <version.org.osgi>4.2.0</version.org.osgi>
     <version.org.slf4j>1.5.10</version.org.slf4j>
     <version.org.slf4j-log4j>1.6.1</version.org.slf4j-log4j>
@@ -210,7 +210,7 @@
         <version>${version.ironjacamar}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.netty</groupId>
+        <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
         <version>${version.netty}</version>
       </dependency>

--- a/stomp-api/pom.xml
+++ b/stomp-api/pom.xml
@@ -19,7 +19,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.jboss.netty</groupId>
+			<groupId>io.netty</groupId>
 			<artifactId>netty</artifactId>
 		</dependency>
 		<dependency>

--- a/stomp-client/pom.xml
+++ b/stomp-client/pom.xml
@@ -29,7 +29,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>

--- a/stomp-common/pom.xml
+++ b/stomp-common/pom.xml
@@ -24,7 +24,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>

--- a/stomp-server-core/pom.xml
+++ b/stomp-server-core/pom.xml
@@ -52,7 +52,7 @@
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>

--- a/stomp-server-spi/pom.xml
+++ b/stomp-server-spi/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
 


### PR DESCRIPTION
In order to upgrade HornetQ to 3.4.5.Final, we must also upgrade Netty to 3.4.5.Final.

AS7 also has a dependency to stilts (for OSGi integration test). This PR would ensure that we could use a stilts release with the same Netty version.
