### PR TITLE
Eliminate or replace presumably-spurious LGPL notices.

### DIFF
--- a/conduit-server-core/src/test/resources/logging.properties
+++ b/conduit-server-core/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap

--- a/stomp-client-js/src/test/resources/logging.properties
+++ b/stomp-client-js/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap

--- a/stomp-client/src/test/resources/logging.properties
+++ b/stomp-client/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/Handshake.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  * 
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.protocol.websocket;

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf00/Ietf00Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf00/Ietf00Handshake.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  * 
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.protocol.websocket.ietf00;

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf07/Ietf07Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf07/Ietf07Handshake.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.protocol.websocket.ietf07;

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf08/Ietf08Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf08/Ietf08Handshake.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.protocol.websocket.ietf08;

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf17/Ietf17Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf17/Ietf17Handshake.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.protocol.websocket.ietf17;

--- a/stomp-server-core/src/main/java/org/projectodd/stilts/stomp/server/websockets/protocol/ServerHandshakeHandler.java
+++ b/stomp-server-core/src/main/java/org/projectodd/stilts/stomp/server/websockets/protocol/ServerHandshakeHandler.java
@@ -1,20 +1,17 @@
 /*
  * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
  * 
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.projectodd.stilts.stomp.server.websockets.protocol;

--- a/stomp-server-core/src/test/resources/logging.properties
+++ b/stomp-server-core/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap

--- a/stomplet-api/src/main/java/org/projectodd/stilts/stomplet/Subscriber.java
+++ b/stomplet-api/src/main/java/org/projectodd/stilts/stomplet/Subscriber.java
@@ -1,21 +1,3 @@
-/*
- * Copyright 2008-2011 Red Hat, Inc, and individual contributors.
- * 
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- * 
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- */
 
 package org.projectodd.stilts.stomplet;
 

--- a/stomplet-server-bundle-tests/src/test/resources/logging.properties
+++ b/stomplet-server-bundle-tests/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap

--- a/stomplet-server-core/src/test/resources/logging.properties
+++ b/stomplet-server-core/src/test/resources/logging.properties
@@ -1,24 +1,3 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2010, Red Hat, Inc., and individual contributors
-# as indicated by the @author tags. See the copyright.txt file in the
-# distribution for a full listing of individual contributors.
-#
-# This is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation; either version 2.1 of
-# the License, or (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this software; if not, write to the Free
-# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-#
 
 # Additional logger names to configure (root logger is always configured)
 loggers=org.jboss.shrinkwrap


### PR DESCRIPTION
There are a small number of Stilts files that have LGPL notices. Some of these are non-meaningful (like on logging.properties files) while others seem like they must have been included by mistake; as to the former I've deleted the notices, and as to the latter I've replaced the LGPL notices with Apache License 2.0 notices.
