### PR TITLE
Netty 3.5.11.Final support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <version.jboss.arquillian>1.0.0.CR4</version.jboss.arquillian>
     <version.jboss.as7>7.0.1.Final</version.jboss.as7>
     <version.jboss-logging>3.0.0.CR1</version.jboss-logging>
+    <version.jboss-logmanager>1.3.2.Final</version.jboss-logmanager>
     <version.jboss-naming>5.0.6.CR1</version.jboss-naming>
     <version.jboss-stdio>1.0.0.CR3</version.jboss-stdio>
     <version.jbossts>4.15.1.Final</version.jbossts>
@@ -53,7 +54,7 @@
     <version.junit>4.7</version.junit>
     <version.log4j>1.2.16</version.log4j>
     <version.mockito>1.8.4</version.mockito>
-    <version.netty>3.2.1.Final</version.netty>
+    <version.netty>3.5.11.Final</version.netty>
     <version.org.osgi>4.2.0</version.org.osgi>
     <version.org.slf4j>1.5.10</version.org.slf4j>
     <version.org.slf4j-log4j>1.6.1</version.org.slf4j-log4j>
@@ -185,6 +186,11 @@
         <version>${version.jboss-logging}</version>
       </dependency>
       <dependency>
+        <groupId>org.jboss.logmanager</groupId>
+        <artifactId>jboss-logmanager</artifactId>
+        <version>${version.jboss-logmanager}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.ironjacamar</groupId>
         <artifactId>ironjacamar-common-impl-papaki</artifactId>
         <version>${version.ironjacamar}</version>
@@ -210,7 +216,7 @@
         <version>${version.ironjacamar}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.netty</groupId>
+        <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
         <version>${version.netty}</version>
       </dependency>

--- a/stomp-api/pom.xml
+++ b/stomp-api/pom.xml
@@ -19,7 +19,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.jboss.netty</groupId>
+			<groupId>io.netty</groupId>
 			<artifactId>netty</artifactId>
 		</dependency>
 		<dependency>

--- a/stomp-client-js/src/test/java/org/projectodd/stilts/stomp/client/js/websockets/InstrumentedWebSocket.java
+++ b/stomp-client-js/src/test/java/org/projectodd/stilts/stomp/client/js/websockets/InstrumentedWebSocket.java
@@ -55,7 +55,7 @@ public class InstrumentedWebSocket {
         this.executor = Executors.newFixedThreadPool( 4 );
         VirtualExecutorService bossExecutor = new VirtualExecutorService( this.executor );
         VirtualExecutorService workerExecutor = new VirtualExecutorService( this.executor );
-        bootstrap.setFactory( new NioClientSocketChannelFactory( bossExecutor, workerExecutor ) );
+        bootstrap.setFactory( new NioClientSocketChannelFactory( bossExecutor, workerExecutor, 2 ) );
 
         URI uri = new URI( this.url );
 

--- a/stomp-client/pom.xml
+++ b/stomp-client/pom.xml
@@ -29,7 +29,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
@@ -408,7 +408,7 @@ public class StompClient {
                 this.executor );
         VirtualExecutorService workerExecutor = new VirtualExecutorService(
                 this.executor );
-        return new NioClientSocketChannelFactory( bossExecutor, workerExecutor );
+        return new NioClientSocketChannelFactory( bossExecutor, workerExecutor, 2 );
     }
 
     private static final Callable<Void> NOOP = new Callable<Void>() {

--- a/stomp-common/pom.xml
+++ b/stomp-common/pom.xml
@@ -24,7 +24,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>

--- a/stomp-common/src/test/java/org/projectodd/stilts/stomp/protocol/HandlerEmbedder.java
+++ b/stomp-common/src/test/java/org/projectodd/stilts/stomp/protocol/HandlerEmbedder.java
@@ -15,6 +15,7 @@ import java.util.Queue;
 import org.jboss.netty.buffer.ChannelBufferFactory;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipeline;
@@ -229,6 +230,15 @@ public class HandlerEmbedder {
             }
 
             throw new CodecEmbedderException( actualCause );
+        }
+
+        public ChannelFuture execute(ChannelPipeline pipeline, Runnable task) {
+            try {
+                task.run();
+                return Channels.succeededFuture(pipeline.getChannel());
+            } catch (Throwable t) {
+                return Channels.failedFuture(pipeline.getChannel(), t);
+            }
         }
     }
 

--- a/stomp-server-core/pom.xml
+++ b/stomp-server-core/pom.xml
@@ -52,12 +52,16 @@
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>jboss-logmanager</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectodd.stilts</groupId>

--- a/stomp-server-spi/pom.xml
+++ b/stomp-server-spi/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.netty</groupId>
+      <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
     </dependency>
 


### PR DESCRIPTION
This pull requests updates Netty to latest released version in `3.5.x`. It introduces also a required `jboss-logmanager` dependency. Additionally a small fix for netty was added to prevent the tests from hanging.
