### PR TITLE
Using standardised value for stomp (as WebSocket Protocol)

### DIFF
--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf00/Ietf00Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf00/Ietf00Handshake.java
@@ -63,7 +63,7 @@ public class Ietf00Handshake extends Handshake {
         request.addHeader( HttpHeaders.Names.CONNECTION, "Upgrade" );
         request.addHeader( HttpHeaders.Names.UPGRADE, "WebSocket" );
         request.addHeader( HttpHeaders.Names.HOST, uri.getHost()+ ":" + uri.getPort() );
-        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "stomp" );
+        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "v11.stomp" );
 
         request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_KEY1, this.challenge.getKey1String() );
         request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_KEY2, this.challenge.getKey2String() );

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf07/Ietf07Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf07/Ietf07Handshake.java
@@ -68,7 +68,7 @@ public class Ietf07Handshake extends Handshake {
         request.addHeader( HttpHeaders.Names.CONNECTION, "Upgrade" );
         request.addHeader( HttpHeaders.Names.UPGRADE, "WebSocket" );
         request.addHeader( HttpHeaders.Names.HOST, uri.getHost()+ ":" + uri.getPort() );
-        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "stomp" );
+        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "v11.stomp" );
 
         request.addHeader( "Sec-WebSocket-Key", this.challenge.getNonceBase64() );
         request.setContent( ChannelBuffers.EMPTY_BUFFER );

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf08/Ietf08Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf08/Ietf08Handshake.java
@@ -72,7 +72,7 @@ public class Ietf08Handshake extends Handshake {
         request.addHeader( HttpHeaders.Names.CONNECTION, "Upgrade" );
         request.addHeader( HttpHeaders.Names.UPGRADE, "WebSocket" );
         request.addHeader( HttpHeaders.Names.HOST, uri.getHost()+ ":" + uri.getPort() );
-        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "stomp" );
+        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "v11.stomp" );
 
         request.addHeader( "Sec-WebSocket-Key", this.challenge.getNonceBase64() );
         request.setContent( ChannelBuffers.EMPTY_BUFFER );

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf17/Ietf17Handshake.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/websocket/ietf17/Ietf17Handshake.java
@@ -72,7 +72,7 @@ public class Ietf17Handshake extends Handshake {
         request.addHeader( HttpHeaders.Names.CONNECTION, "Upgrade" );
         request.addHeader( HttpHeaders.Names.UPGRADE, "WebSocket" );
         request.addHeader( HttpHeaders.Names.HOST, uri.getHost()+ ":" + uri.getPort() );
-        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "stomp" );
+        request.addHeader( HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL, "v11.stomp" );
 
         request.addHeader( "Sec-WebSocket-Key", this.challenge.getNonceBase64() );
         request.setContent( ChannelBuffers.EMPTY_BUFFER );


### PR DESCRIPTION
the v11.stomp value is the one that is registered / IANA:
http://www.iana.org/assignments/websocket/websocket.xml

Also the HornetQ broker uses that:
https://github.com/hornetq/hornetq/blob/master/hornetq-server/src/main/java/org/hornetq/core/protocol/stomp/WebSocketServerHandler.java#L84
