### PR TITLE
Allow for headers to be passed into ruby stomp client

### DIFF
--- a/conduit-server-core/pom.xml
+++ b/conduit-server-core/pom.xml
@@ -47,6 +47,7 @@
   <dependency>
    <groupId>org.jboss.jbossts</groupId>
    <artifactId>jbossjta</artifactId>
+   <version>4.16.6.Final</version>
    <scope>test</scope>
   </dependency>
 

--- a/stomp-client-rb/lib/stilts/stomp/client.rb
+++ b/stomp-client-rb/lib/stilts/stomp/client.rb
@@ -23,7 +23,7 @@ module Stilts
 
         if headers
           # convert Ruby hash to org.projectodd.stilts.stomp.Headers
-          stomp_headers = org.projectodd.stilts.stomp.Headers.new
+          stomp_headers = org.projectodd.stilts.stomp.DefaultHeaders.new
           headers.each do |key,val|
             stomp_headers.put(key.to_s, val.to_s)
           end

--- a/stomp-client-rb/lib/stilts/stomp/client.rb
+++ b/stomp-client-rb/lib/stilts/stomp/client.rb
@@ -17,8 +17,24 @@ module Stilts
 
       alias_method :original_send, :send
     
-      def send(destination, message)
-        stomp_message = org.projectodd.stilts.stomp::StompMessages.createStompMessage( destination, message )
+      def send(destination, message, headers = nil)
+
+        method_args = [destination]
+
+        if headers
+          # convert Ruby hash to org.projectodd.stilts.stomp.Headers
+          stomp_headers = org.projectodd.stilts.stomp.Headers.new
+          headers.each do |key,val|
+            stomp_headers.put(key.to_s, val.to_s)
+          end
+          method_args << stomp_headers
+        end
+
+        method_args << message
+
+
+        stomp_message = org.projectodd.stilts.stomp::StompMessages.createStompMessage( *method_args )
+
         original_send( stomp_message )
       end
 

--- a/stomplet-server-cdi/pom.xml
+++ b/stomplet-server-cdi/pom.xml
@@ -34,10 +34,12 @@
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-spi</artifactId>
+        <version>2.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core</artifactId>
+        <version>2.0.0.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.el</groupId>

--- a/stomplet-server-core/pom.xml
+++ b/stomplet-server-core/pom.xml
@@ -52,6 +52,7 @@
     <dependency>
       <groupId>org.jboss.jbossts</groupId>
       <artifactId>jbossjta</artifactId>
+      <version>4.16.6.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Allow for an optional hash that will get converted into a DefaultHeader.

I am not quite sure how/where the tests are for the ruby client. Also, to get the tests to pass, I added versions to a couple dependencies
