### PR TITLE
Allow passing username and password to .connect() in JS client

### DIFF
--- a/stomp-client-js/src/main/javascript/stomp.js
+++ b/stomp-client-js/src/main/javascript/stomp.js
@@ -809,7 +809,7 @@ Stomp.Transport.HTTP.prototype = {
     var timeoutHandle = setTimeout( function() {
       if ( request.readyState != 0 && request.readyState != 4 ) {
         request.abort();
-        errorCallack();
+        errorCallback();
       }
     }, 5000 );
     

--- a/stomp-client-js/src/main/javascript/stomp.js
+++ b/stomp-client-js/src/main/javascript/stomp.js
@@ -143,11 +143,11 @@ Stomp.Client.prototype = {
       this._errorCallback = arguments[3];
     }
     
-    this._connectTransport(callback);
+    this._connectTransport();
     
   },
   
-  _connectTransport: function(callback) {
+  _connectTransport: function() {
     var transports = [];
     for ( i = 0 ; i < Stomp.Transports.length ; ++i ) {
        var t = new Stomp.Transports[i]( this._host, this._port, this._secure );
@@ -155,11 +155,12 @@ Stomp.Client.prototype = {
        transports.push( t );
      }
      
-     this._buildConnector( transports, 0, callback )();
+     this._buildConnector( transports, 0 )();
   },
   
   
-  _buildConnector: function(transports, i, callback) {
+  _buildConnector: function(transports, i) {
+    var callback = this._connectCallback;
     var client = this;
     if ( i+1 < transports.length ) {
       return function() {

--- a/stomp-client-js/src/main/javascript/stomp.js
+++ b/stomp-client-js/src/main/javascript/stomp.js
@@ -162,7 +162,7 @@ Stomp.Client.prototype = {
   _buildConnector: function(transports, i) {
     var callback = this._connectCallback;
     var client = this;
-    if ( i+1 < transports.length ) {
+    if ( i < transports.length ) {
       return function() {
         var fallback = client._buildConnector( transports, i+1, callback );
         try {
@@ -174,22 +174,8 @@ Stomp.Client.prototype = {
           fallback();
         }
       };
-    } else if ( i < transports.length ) {
-      return function() {
-        var fallback = client.connectionFailed.bind( this );
-        try {
-          transports[i].connect( function() {
-            client._transport = transports[i];
-            callback();
-          }, client.connectionFailed.bind( this ) );
-        } catch(err) {
-          fallback();
-        }
-      };
     } else {
-      return function() {
-        client.connectionFailed(this);
-      };
+      return client.connectionFailed.bind(this);
     }
   },
   

--- a/stomp-client-js/src/main/javascript/stomp.js
+++ b/stomp-client-js/src/main/javascript/stomp.js
@@ -194,7 +194,14 @@ Stomp.Client.prototype = {
   },
   
   connectionFailed: function() {
-    Stomp.logger.log( "unable to connect" );
+    if (this._errorCallback)
+    {
+    	this._errorCallback.apply(this._errorCallback, arguments);
+    }
+    else
+    {
+    	Stomp.logger.log( "unable to connect" );
+    }
   },
   
   disconnect: function(disconnectCallback) {


### PR DESCRIPTION
First off, apologies to not updating the test suite. I could not figure out how it all ties together.

Stomp.Client#connect does not accept more parameters than one without raising an error on connect. It all works fine, but if supplying more than one parameter to connect, the onConnected callback won’t be called.

Additionally I fixed a typo for the errorCallback in the HTTP transport.

I also added support for the errorCallback, which allows users to suppress the logging message sent on error.
