### PR TITLE
Stomp-Client: add authentication to connection process

### DIFF
--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
@@ -81,6 +81,21 @@ class ClientContextImpl implements ClientContext {
     	return this.client.getSSLContext();
     }
 
+    @Override
+    public boolean isAuthenticated() {
+        return client.isAuthenticated();
+    }
+
+    @Override
+    public String getUsername() {
+        return client.getAuthenticationUser();
+    }
+
+    @Override
+    public String getPassword() {
+        return client.getAuthentiactionPassword();
+    }
+
     private StompClient client;
 
 }

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
@@ -93,7 +93,7 @@ class ClientContextImpl implements ClientContext {
 
     @Override
     public String getPassword() {
-        return client.getAuthentiactionPassword();
+        return client.getAuthenticationPassword();
     }
 
     private StompClient client;

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
@@ -113,12 +113,13 @@ public class StompClient {
             
         }
 
-        if (uri.getUserInfo() != null) {
-            String[] authenticationTokens = uri.getUserInfo().split(":");
-            if (authenticationTokens.length == 2) {
+        String userInfo = uri.getUserInfo();
+        if (userInfo != null) {
+            int firstColonIndex = userInfo.indexOf(":");
+            if (firstColonIndex > -1 && firstColonIndex < (userInfo.length() - 1)) {
                 this.useAuthentication = true;
-                this.authenticationUser = authenticationTokens[0];
-                this.authenticationPassword = authenticationTokens[1];
+                this.authenticationUser = userInfo.substring(0, firstColonIndex);
+                this.authenticationPassword = userInfo.substring(firstColonIndex + 1);
             }
         }
 

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
@@ -118,7 +118,7 @@ public class StompClient {
             if (authenticationTokens.length == 2) {
                 this.useAuthentication = true;
                 this.authenticationUser = authenticationTokens[0];
-                this.authentiactionPassword = authenticationTokens[1];
+                this.authenticationPassword = authenticationTokens[1];
             }
         }
 
@@ -133,8 +133,8 @@ public class StompClient {
         return this.authenticationUser;
     }
 
-    public String getAuthentiactionPassword() {
-        return this.authentiactionPassword;
+    public String getAuthenticationPassword() {
+        return this.authenticationPassword;
     }
 
     public boolean isSecure() {
@@ -512,7 +512,7 @@ public class StompClient {
     private boolean useSSL = false;
     private boolean useAuthentication = false;
     private String authenticationUser;
-    private String authentiactionPassword;
+    private String authenticationPassword;
     private Class<? extends Handshake> webSocketHandshakeClass = Ietf17Handshake.class;
     private SSLContext sslContext;
 

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
@@ -112,7 +112,29 @@ public class StompClient {
             }
             
         }
+
+        if (uri.getUserInfo() != null) {
+            String[] authenticationTokens = uri.getUserInfo().split(":");
+            if (authenticationTokens.length == 2) {
+                this.useAuthentication = true;
+                this.authenticationUser = authenticationTokens[0];
+                this.authentiactionPassword = authenticationTokens[1];
+            }
+        }
+
         this.serverAddress = new InetSocketAddress( host, port );
+    }
+
+    public boolean isAuthenticated() {
+        return this.useAuthentication;
+    }
+
+    public String getAuthenticationUser() {
+        return this.authenticationUser;
+    }
+
+    public String getAuthentiactionPassword() {
+        return this.authentiactionPassword;
     }
 
     public boolean isSecure() {
@@ -488,6 +510,9 @@ public class StompClient {
     private Version version = Version.VERSION_1_0;
     private boolean useWebSockets = false;
     private boolean useSSL = false;
+    private boolean useAuthentication = false;
+    private String authenticationUser;
+    private String authentiactionPassword;
     private Class<? extends Handshake> webSocketHandshakeClass = Ietf17Handshake.class;
     private SSLContext sslContext;
 

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/ClientContext.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/ClientContext.java
@@ -32,7 +32,11 @@ public interface ClientContext {
     
     boolean isSecure();
     SSLContext getSSLContext();
-    
+
+    boolean isAuthenticated();
+    String getUsername();
+    String getPassword();
+
     void setConnectionState(State state);
     void setVersion(Version version);
     

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/StompConnectionNegotiator.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/StompConnectionNegotiator.java
@@ -34,6 +34,10 @@ public class StompConnectionNegotiator extends AbstractClientControlFrameHandler
         StompControlFrame frame = new StompControlFrame( Command.CONNECT );
         frame.setHeader( Header.HOST, this.host );
         frame.setHeader( Header.ACCEPT_VERSION, Version.supportedVersions() );
+        if(getClientContext().isAuthenticated()) {
+            frame.setHeader( Header.LOGIN, getClientContext().getUsername() );
+            frame.setHeader( Header.PASSCODE, getClientContext().getPassword() );
+        }
 
         Channels.write( context.getChannel(), frame );
     }

--- a/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/MockClientContext.java
+++ b/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/MockClientContext.java
@@ -36,7 +36,22 @@ public class MockClientContext implements ClientContext {
 	public SSLContext getSSLContext() {
 		return this.sslContext;
 	}
-	
+
+    @Override
+    public boolean isAuthenticated() {
+        return this.authenticated;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.user;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
     @Override
     public State getConnectionState() {
         return this.state;
@@ -90,6 +105,9 @@ public class MockClientContext implements ClientContext {
     private Version version = Version.VERSION_1_0;
     private boolean secure = false;
     private SSLContext sslContext;
+    private boolean authenticated = false;
+    private String user;
+    private String password;
     
     
     private List<String> receipts = new ArrayList<String>();

--- a/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/StompFrame.java
+++ b/stomp-common/src/main/java/org/projectodd/stilts/stomp/protocol/StompFrame.java
@@ -94,6 +94,8 @@ public class StompFrame {
         public static final String SERVER = "server";
         public static final String MESSAGE = "message";
         public static final String HEARTBEAT = "heart-beat";
+        public static final String LOGIN = "login";
+        public static final String PASSCODE = "passcode";
     }
 
     public static class Command {


### PR DESCRIPTION
This should fix #15

Known issues: you can't have passwords or usernames with colons in them. (Anyone know of suitable framework code to parse a URI.getUserInfo() in a standards-compliant way?)
