### PR TITLE
Fix typo in Subscriber method; getParamters => getParameters()

### DIFF
--- a/stomplet-api/src/main/java/org/projectodd/stilts/stomplet/Subscriber.java
+++ b/stomplet-api/src/main/java/org/projectodd/stilts/stomplet/Subscriber.java
@@ -33,6 +33,6 @@ public interface Subscriber extends AcknowledgeableMessageSink {
     AckMode getAckMode();
     StompSession getSession();
     String getParameter(String name);
-    Map<String,String> getParamters();
+    Map<String,String> getParameters();
 
 }

--- a/stomplet-server-core/src/main/java/org/projectodd/stilts/stomplet/container/SubscriberImpl.java
+++ b/stomplet-server-core/src/main/java/org/projectodd/stilts/stomplet/container/SubscriberImpl.java
@@ -132,7 +132,7 @@ public class SubscriberImpl implements Subscriber {
         return this.parameters.get(  name  );
     }
     
-    public Map<String,String> getParamters() {
+    public Map<String,String> getParameters() {
         return this.parameters;
     }
     

--- a/stomplet-server-core/src/main/java/org/projectodd/stilts/stomplet/container/xa/PseudoXAStomplet.java
+++ b/stomplet-server-core/src/main/java/org/projectodd/stilts/stomplet/container/xa/PseudoXAStomplet.java
@@ -59,7 +59,7 @@ public class PseudoXAStomplet implements XAStomplet {
     public void onSubscribe(Subscriber subscriber) throws StompException {
         log.debug(  "PXAStomplet on_subscribe: " + this.resourceManager );
         String subscriptionId = subscriber.getSubscriptionId();
-        Subscriber xaSubscriber = new SubscriberImpl( subscriber.getSession(), stomplet, subscriptionId, subscriber.getDestination(), subscriber.getParamters(), new PseudoXAStompletAcknowledgeableMessageSink( this.resourceManager, subscriber ), subscriber.getAckMode() );
+        Subscriber xaSubscriber = new SubscriberImpl( subscriber.getSession(), stomplet, subscriptionId, subscriber.getDestination(), subscriber.getParameters(), new PseudoXAStompletAcknowledgeableMessageSink( this.resourceManager, subscriber ), subscriber.getAckMode() );
         this.subscribers.put( subscriber.getId(), xaSubscriber );
         this.stomplet.onSubscribe( xaSubscriber );
     }


### PR DESCRIPTION
I fixed the typo using project-wide Find & Replace, hope I got all occurrences.
