### PR TITLE
Add support for paths in websocket URL

### DIFF
--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/ClientContextImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Red Hat, Inc, and individual contributors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package org.projectodd.stilts.stomp.client;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 
 import javax.net.ssl.SSLContext;
 
@@ -26,26 +27,31 @@ import org.projectodd.stilts.stomp.client.protocol.ClientContext;
 import org.projectodd.stilts.stomp.protocol.StompFrame.Version;
 
 class ClientContextImpl implements ClientContext {
-    
+
     ClientContextImpl(StompClient client) {
         this.client = client;
     }
-    
+
     @Override
     public InetSocketAddress getServerAddress() {
         return this.client.getServerAddress();
     }
 
     @Override
+    public URI getWebSocketAddress() {
+        return client.getWebSocketAddress();
+    }
+
+    @Override
     public State getConnectionState() {
         return this.client.getConnectionState();
     }
-    
+
     @Override
     public Version getVersion() {
         return this.client.getVersion();
     }
-    
+
     @Override
     public boolean isSecure() {
     	return this.client.isSecure();
@@ -59,8 +65,8 @@ class ClientContextImpl implements ClientContext {
     @Override
     public void setVersion(Version version) {
         this.client.setVersion( version );
-    }    
-    
+    }
+
     @Override
     public void messageReceived(StompMessage message) {
         this.client.messageReceived( message );
@@ -75,7 +81,7 @@ class ClientContextImpl implements ClientContext {
     public void receiptReceived(String receiptId) {
         this.client.receiptReceived( receiptId );
     }
-    
+
     @Override
     public SSLContext getSSLContext() {
     	return this.client.getSSLContext();

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClient.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Red Hat, Inc, and individual contributors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -103,16 +103,21 @@ public class StompClient {
                 this.useSSL = true;
             }
         }
-        
+
         if ( port < 0 ) {
             if ( useSSL ) {
                 port = Constants.DEFAULT_SECURE_PORT;
             } else {
                 port = Constants.DEFAULT_PORT;
             }
-            
+
         }
         this.serverAddress = new InetSocketAddress( host, port );
+        if( useWebSockets ) {
+            this.webSocketAddress = new URI(this.useSSL ? "wss" : "ws" + "://" + host + ":" + port + uri.getPath());
+        } else {
+            this.webSocketAddress = null;
+        }
     }
 
     public boolean isSecure() {
@@ -459,7 +464,12 @@ public class StompClient {
         return new NioClientSocketChannelFactory( bossExecutor, workerExecutor, 2 );
     }
 
+    public URI getWebSocketAddress() {
+        return webSocketAddress;
+    }
+
     private static final Callable<Void> NOOP = new Callable<Void>() {
+        @Override
         public Void call() throws Exception {
             return null;
         }
@@ -485,6 +495,7 @@ public class StompClient {
     private boolean destroyExecutor = false;
     private Channel channel;
     private InetSocketAddress serverAddress;
+    private final URI webSocketAddress;
     private Version version = Version.VERSION_1_0;
     private boolean useWebSockets = false;
     private boolean useSSL = false;

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClientPipelineFactory.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/StompClientPipelineFactory.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Red Hat, Inc, and individual contributors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,7 +74,7 @@ public class StompClientPipelineFactory implements ChannelPipelineFactory {
         if (this.handshake != null) {
             pipeline.addLast( "http-encoder", new HttpRequestEncoder() );
             pipeline.addLast( "http-decoder", new WebSocketHttpResponseDecoder( this.handshake ) );
-            pipeline.addLast( "websocket-connection-negotiator", new WebSocketConnectionNegotiator( this.clientContext.getServerAddress(), this.handshake, this.clientContext.isSecure() ) );
+            pipeline.addLast( "websocket-connection-negotiator", new WebSocketConnectionNegotiator( this.clientContext.getWebSocketAddress(), this.handshake ) );
             pipeline.addLast( "stomp-frame-decoder", new WebSocketStompFrameDecoder() );
             pipeline.addLast( "stomp-frame-encoder", new WebSocketStompFrameEncoder() );
         } else {

--- a/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/ClientContext.java
+++ b/stomp-client/src/main/java/org/projectodd/stilts/stomp/client/protocol/ClientContext.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Red Hat, Inc, and individual contributors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package org.projectodd.stilts.stomp.client.protocol;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 
 import javax.net.ssl.SSLContext;
 
@@ -25,17 +26,19 @@ import org.projectodd.stilts.stomp.client.StompClient.State;
 import org.projectodd.stilts.stomp.protocol.StompFrame.Version;
 
 public interface ClientContext {
-    
+
     InetSocketAddress getServerAddress();
+    URI getWebSocketAddress();
+
     State getConnectionState();
     Version getVersion();
-    
+
     boolean isSecure();
     SSLContext getSSLContext();
-    
+
     void setConnectionState(State state);
     void setVersion(Version version);
-    
+
     void receiptReceived(String receiptId);
     void messageReceived(StompMessage message);
     void errorReceived(StompMessage message);

--- a/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/MockClientContext.java
+++ b/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/MockClientContext.java
@@ -1,6 +1,7 @@
 package org.projectodd.stilts.stomp.client;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,32 +17,44 @@ public class MockClientContext implements ClientContext {
     public void setServerAddress(InetSocketAddress serverAddress) {
         this.serverAddress = serverAddress;
     }
-    
+
+    @Override
     public InetSocketAddress getServerAddress() {
         return this.serverAddress;
     }
-    
-	public void setSecure(boolean secure) {
+
+    public void setWebSocketAddress(URI webSocketAddress) {
+        this.webSocketAddress = webSocketAddress;
+    }
+
+    @Override
+    public URI getWebSocketAddress() {
+        return webSocketAddress;
+    }
+
+    public void setSecure(boolean secure) {
 		this.secure = secure;
 	}
-	
-	public boolean isSecure() {
+
+	@Override
+    public boolean isSecure() {
 		return this.secure;
 	}
-	
+
 	public void setSSLContext(SSLContext sslContext) {
 		this.sslContext = sslContext;
 	}
-	
-	public SSLContext getSSLContext() {
+
+	@Override
+    public SSLContext getSSLContext() {
 		return this.sslContext;
 	}
-	
+
     @Override
     public State getConnectionState() {
         return this.state;
     }
-    
+
     @Override
     public Version getVersion() {
         return this.version;
@@ -56,7 +69,7 @@ public class MockClientContext implements ClientContext {
     public void receiptReceived(String receiptId) {
         this.receipts.add( receiptId );
     }
-    
+
     public List<String> getReceipts() {
         return this.receipts;
     }
@@ -65,7 +78,7 @@ public class MockClientContext implements ClientContext {
     public void messageReceived(StompMessage message) {
         this.messages.add( message );
     }
-    
+
     public List<StompMessage> getMessages() {
         return this.messages;
     }
@@ -75,7 +88,7 @@ public class MockClientContext implements ClientContext {
         this.errors.add( message );
     }
 
-    
+
     public List<StompMessage> getErrors() {
         return this.errors;
     }
@@ -83,15 +96,16 @@ public class MockClientContext implements ClientContext {
     @Override
     public void setVersion(Version version) {
         this.version = version;
-    }    
-    
+    }
+
+    private URI webSocketAddress;
     private InetSocketAddress serverAddress;
     private State state;
     private Version version = Version.VERSION_1_0;
     private boolean secure = false;
     private SSLContext sslContext;
-    
-    
+
+
     private List<String> receipts = new ArrayList<String>();
     private List<StompMessage> messages = new ArrayList<StompMessage>();
     private List<StompMessage> errors = new ArrayList<StompMessage>();

--- a/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/protocol/websockets/WebSocketConnectionNegotiatorTest.java
+++ b/stomp-client/src/test/java/org/projectodd/stilts/stomp/client/protocol/websockets/WebSocketConnectionNegotiatorTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.net.InetSocketAddress;
+import java.net.URI;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -28,7 +28,7 @@ public class WebSocketConnectionNegotiatorTest {
         Ietf00Handshake handshake = new Ietf00Handshake();
         HandlerEmbedder handler = new HandlerEmbedder( false,
                 new WebSocketHttpResponseDecoder( handshake ),
-                new WebSocketConnectionNegotiator( new InetSocketAddress( "localhost", 8675 ), handshake, false ) );
+                new WebSocketConnectionNegotiator( URI.create( "ws://localhost:8675/" ), handshake ) );
 
         ChannelPipeline pipeline = handler.getPipeline();
 
@@ -68,7 +68,7 @@ public class WebSocketConnectionNegotiatorTest {
         Ietf00Handshake handshake = new Ietf00Handshake();
         HandlerEmbedder handler = new HandlerEmbedder( false,
                 new WebSocketHttpResponseDecoder( handshake ),
-                new WebSocketConnectionNegotiator( new InetSocketAddress( "localhost", 8675 ) , handshake, false ) );
+                new WebSocketConnectionNegotiator( URI.create( "ws://localhost:8675/" ), handshake ) );
 
         ChannelPipeline pipeline = handler.getPipeline();
 

--- a/stomp-client/src/test/resources/logging.properties
+++ b/stomp-client/src/test/resources/logging.properties
@@ -33,7 +33,7 @@ logger.handlers=FILE, CONSOLE
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
+handler.CONSOLE.level=DEBUG
 handler.CONSOLE.autoFlush=true
 handler.CONSOLE.formatter=PATTERN
 


### PR DESCRIPTION
The attached pull request provides support for paths in websocket addresses; 0.1.40 will only connect to addresses in the format stomp+ws://host:port/ - this enhancements allows addresses in the form stomp+ws://host:port/path/to/resource
